### PR TITLE
fixed bubble and added device

### DIFF
--- a/src/Monolog/Handler/PushbulletHandler.php
+++ b/src/Monolog/Handler/PushbulletHandler.php
@@ -11,16 +11,19 @@ class PushbulletHandler extends AbstractProcessingHandler
 {
     protected $headers;
 
-    protected $devices = null;
-
     protected $guzzle;
 
     protected $apiUrl = 'https://api.pushbullet.com/v2/';
+    
+    protected $deviceIden;
 
-    public function __construct($accessToken = null, $level = Logger::DEBUG, $bubble = true)
+    public function __construct($accessToken = null, $level = Logger::DEBUG, $bubble = true, $deviceIden = null)
     {
         if ($accessToken === null) {
             throw new Exception('You need to specify Pushbullet access token.');
+        }
+        if ($deviceIden !== null) {
+            $this->deviceIden = $deviceIden;
         }
 
         $this->guzzle = new GuzzleClient(['base_uri' => $this->apiUrl]);
@@ -29,14 +32,20 @@ class PushbulletHandler extends AbstractProcessingHandler
             'Content-Type' => 'application/json',
         );
 
-        parent::__construct($level, $buble);
+        parent::__construct($level, $bubble);
     }
 
     public function write(array $record)
     {
+        if ($this->deviceIden !== null) {
+            $json = array('type' => 'note', 'title' => $_SERVER['HTTP_HOST'], 'body' => $record['message'], 'device_iden' => $this->deviceIden);
+        } else {
+            $json = array('type' => 'note', 'title' => $_SERVER['HTTP_HOST'], 'body' => $record['message']);
+        }
+        
         $this->guzzle->post('pushes', array(
             'headers' => $this->headers,
-            'json' => array('type' => 'note', 'title' => $_SERVER['HTTP_HOST'], 'body' => $record['message'])
+            'json' => $json
         ));
     }
 }


### PR DESCRIPTION
1. Typo in line 35 was `parent::__construct($level, $buble);` fixed to `$bubble`
2. Introduced the possibility of setting a device with `$deviceIden` (you'll find it in the URL in the backend on the tab "Devices"), which translates to `device_iden` in the POST Request, see API Documentation: https://docs.pushbullet.com/#create-push. If none is given, the message stays as it was before
3. removed unused `$devices`

Background: We use PushBullet (and thus the same settings) for several things, but error logs should only go to the IT team. As for now only one device.
